### PR TITLE
Makes `title` prop accepts not only `string` type, but `element` also…

### DIFF
--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -39,7 +39,10 @@ Tabs.propTypes = {
       PropTypes.string,
       PropTypes.number
     ]),
-    title: PropTypes.string.isRequired,
+    title: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element
+    ]).isRequired
   })).isRequired,
   onClick: PropTypes.func,
   activeId: PropTypes.oneOfType([


### PR DESCRIPTION
… (#565)

To make tab title text with icon, React element can be provided, but validator throws annoying error in this case...